### PR TITLE
Added vscode into exclude IDE list in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # Exclude IDE and Editor files
 /.idea/
+/.vscode/
 *.sublime*
 
 **/node_modules


### PR DESCRIPTION
VS code is the most widely used editor for JavaScript. The configurations of vscode are stored in .vscode folder and which is not needed for the repository. So, I am adding .vscode in gitignore ...

Signed-off-by: Yash Vaghvani <yashvadhvani@gmail.com>