### PR TITLE
upgrade zeromq version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "protobufjs": "^6.7.3",
     "secp256k1": "^3.2.5",
     "uuid": "^3.0.1",
-    "zeromq": "^4.2.1"
+    "zeromq": "^5.2.8"
   },
   "devDependencies": {
     "mocha": "^3.2.0",


### PR DESCRIPTION
Currently, the installation from npm fails on node 17. 

This relates to:

- https://github.com/hyperledger/sawtooth-sdk-javascript/issues/22
- https://github.com/zeromq/zeromq.js/issues/430